### PR TITLE
feat: support multiple tabpages, multiple vim instance and statusline/winbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,41 @@ default_keymaps = true -- Enable default keymaps.
 vim.keymap.set('n', '<Leader>z', "<Cmd>lua require('maximize').toggle()<CR>")
 ```
 
+## 🚥 statusline & winbar
+
+Use the tabpage-scoped variable `vim.t.maximized` to check whether the current window
+is maximized or not.
+
+### Lualine
+
+```lua
+local function maximize_status()
+  return vim.t.maximized and '   ' or ''
+end
+
+require('lualine').setup {
+  sections = {
+    lualine_c = { maximize_status }
+  }
+}
+```
+
+### winbar
+
+```lua
+-- ~/.config/nvim/lua/winbar.lua
+local M = {}
+
+M.maximize_status = function()
+  return vim.t.maximized and '   ' or ''
+end
+
+return M
+
+-- ~/.config/nvim/init.lua
+vim.o.winbar = "%{%v:lua.require('winbar').maximize_status()%}"
+```
+
 ## ℹ️ API
 
 * Toggle maximizing the current window:

--- a/lua/maximize/init.lua
+++ b/lua/maximize/init.lua
@@ -16,23 +16,21 @@ M.setup = function(user_config)
   end
 
   -- AUTOCMDS:
+  -- Clean cache upon exiting vim (delete the temporary session file for each
+  -- tabpage)
 
   if vim.fn.has('nvim-0.7.0') == 1 then
     local autocmd = vim.api.nvim_create_autocmd
     local augroup = vim.api.nvim_create_augroup
-
-    -- Delete session file from cache.
-    autocmd({ 'VimEnter', 'VimLeave' }, {
-      command = "call delete(getenv('HOME') . '/.cache/nvim/.maximize_session.vim')",
+    autocmd({ 'VimLeave' }, {
       group = augroup('clear_maximize_cache', {}),
+      callback = require('maximize.utils').delete_session_files
     })
   else
-    -- Delete session file from cache.
     vim.cmd([[
     aug clear_maximize_cache
     au!
-    au VimEnter * call delete(getenv('HOME') . '/.cache/nvim/.maximize_session.vim')
-    au VimLeave * call delete(getenv('HOME') . '/.cache/nvim/.maximize_session.vim')
+    au VimLeave * lua require('maximize.utils').delete_session_files()
     aug END
     ]])
   end

--- a/lua/maximize/utils.lua
+++ b/lua/maximize/utils.lua
@@ -39,4 +39,11 @@ utils.is_array = function(t)
   return true
 end
 
+utils.delete_session_files = function()
+  local tabpages = vim.api.nvim_list_tabpages()
+  for _, tabpage_num in ipairs(tabpages) do
+    vim.fn.delete(vim.fn.expand(vim.t[tonumber(tabpage_num)].tmp_session_file))
+  end
+end
+
 return utils


### PR DESCRIPTION
I love this plugin. Definitely it is essential when we rely on split windows in our workflow. However, I found that the temporary session file was shared by all windows, so only one window could be maximized regardless of how many tabpages we had, and even how many nvim instances we opened.

To address this limitation, I opened this PR. And add the features below:

1. We can maximize a window in each tabpage
2. We can maximize windows in each nvim instance
3. Export a variable for uses to check whether the current window is maximized or not, so that they can put this status in their statusline or winbar.

I have already tested this PR for a couple of days and it works like a charm. I believe it is worth to merge. 

Thank you 👊