### PR TITLE
Add plugin integrations for aerial and nvim-tree

### DIFF
--- a/lua/maximize/integrations/aerial.lua
+++ b/lua/maximize/integrations/aerial.lua
@@ -1,0 +1,18 @@
+return function()
+  local ok, api = pcall(require, 'aerial')
+  if not ok then
+    return false, nil
+  end
+
+  local cb = function()
+    if not api.is_open() then
+      api.open({ focus = false })
+    end
+  end
+
+  if api.is_open() then
+    api.close()
+    return true, cb
+  end
+  return false, nil
+end

--- a/lua/maximize/integrations/init.lua
+++ b/lua/maximize/integrations/init.lua
@@ -1,0 +1,33 @@
+local M = {
+  callbacks = {}
+}
+local plugins = {
+  require('maximize.integrations.aerial'),
+  require('maximize.integrations.tree'),
+}
+
+function M.clear()
+  local tab = vim.api.nvim_get_current_tabpage()
+  M.callbacks[tab] = {}
+
+  for _, fn in ipairs(plugins) do
+    local ok, cb = fn()
+    if ok then
+      table.insert(M.callbacks[tab], cb)
+    end
+  end
+end
+
+function M.restore()
+  local tab = vim.api.nvim_get_current_tabpage()
+  if M.callbacks[tab] == nil then
+    return
+  end
+
+  for _, fn in ipairs(M.callbacks[tab]) do
+    fn()
+  end
+  M.callbacks[tab] = nil
+end
+
+return M

--- a/lua/maximize/integrations/tree.lua
+++ b/lua/maximize/integrations/tree.lua
@@ -1,0 +1,18 @@
+return function()
+  local ok, api = pcall(require, 'nvim-tree.api')
+  if not ok then
+    return false, nil
+  end
+
+  local cb = function()
+    if not api.tree.is_visible() then
+      api.tree.toggle({ focus = false })
+    end
+  end
+
+  if api.tree.is_visible() then
+    api.tree.close()
+    return true, cb
+  end
+  return false, nil
+end

--- a/lua/maximize/maximize.lua
+++ b/lua/maximize/maximize.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local integrations = require('maximize.integrations')
 local utils = require('maximize.utils')
 
 M.toggle = function()
@@ -11,6 +12,11 @@ M.toggle = function()
 end
 
 M.maximize = function()
+  vim.t.maximized = true
+
+  -- Clear the plugin windows.
+  integrations.clear()
+
   -- Return if only one window exists.
   if vim.fn.winnr('$') == 1 then
     return
@@ -75,11 +81,11 @@ M.maximize = function()
 
   -- Maximize the window.
   vim.cmd('only')
-
-  vim.t.maximized = true
 end
 
 M.restore = function()
+  vim.t.maximized = false
+
   -- Restore windows.
   if vim.fn.filereadable(vim.fn.expand(vim.t.tmp_session_file)) == 1 then
     vim.cmd('silent wall')
@@ -102,7 +108,8 @@ M.restore = function()
     vim.opt_local.cmdwinheight = vim.t.saved_cmdwinheight
   end
 
-  vim.t.maximized = false
+  -- Restore plugin windows.
+  integrations.restore()
 end
 
 return M


### PR DESCRIPTION
Plugins that have windows always open don't get maximized / restored properly (e.g. nvim-tree, aerial).

This PR implements integrations for specific plugins to clear their windows before `maximize.maximize()` and restoring their windows after `maximize.restore()`.