### PR TITLE
[Feature] User events for maximize and restore

### DIFF
--- a/lua/maximize/init.lua
+++ b/lua/maximize/init.lua
@@ -37,6 +37,8 @@ M.maximize = function()
     return
   end
 
+  vim.api.nvim_exec_autocmds('User', { pattern = 'WindowMaximizeStart' })
+
   -- Save options.
   vim.t.saved_cmdheight = vim.opt_local.cmdheight:get()
   vim.t.saved_cmdwinheight = vim.opt_local.cmdwinheight:get()
@@ -103,6 +105,8 @@ M.restore = function()
     -- Restore saved options.
     vim.opt_local.cmdheight = vim.t.saved_cmdheight
     vim.opt_local.cmdwinheight = vim.t.saved_cmdwinheight
+
+    vim.api.nvim_exec_autocmds('User', { pattern = 'WindowRestoreEnd' })
   end
 
   vim.t.maximized = false


### PR DESCRIPTION
I was running into trouble with ToggleTerm not maintaining accurate state information after maximizing / restoring. I added a couple events to make it easier to integrate with other plugins that need to deal with maintaining state external to `Maximize.nvim`.

```lua
local cmd_group = vim.api.nvim_create_augroup("maximize_toggleterm", {})

vim.api.nvim_create_autocmd("User", {
  group = cmd_group,
  pattern = "WindowMaximizeStart",
  callback = function(_)
    local focused_win = vim.api.nvim_get_current_win()
    local toggleterm = require("toggleterm.terminal")

    for _, win in pairs(vim.api.nvim_tabpage_list_wins(0)) do
      local win_type = vim.fn.win_gettype(win)
      if (win_type == "" or win_type == "popup") and win ~= focused_win then
        local buf = vim.api.nvim_win_get_buf(win)
        if is_toggleterm_buffer(buf) then
          local terminal = toggleterm.get(vim.b[buf].toggle_number)
          terminal.window = nil
        end
      end
    end
  end,
  desc = "Clear toggleterm window state before saving session",
})

vim.api.nvim_create_autocmd("User", {
  group = cmd_group,
  pattern = "WindowRestoreEnd",
  callback = function(_)
    local focused_win = vim.api.nvim_get_current_win()
    local toggleterm = require("toggleterm.terminal")

    for _, win in pairs(vim.api.nvim_tabpage_list_wins(0)) do
      if win ~= focused_win then
        local buf = vim.api.nvim_win_get_buf(win)
        if is_toggleterm_buffer(buf) then
          local terminal = toggleterm.get(vim.b[buf].toggle_number)
          terminal.window = win
        end
      end
    end
  end,
  desc = "Update toggleterm window state after restoring session",
})
```
